### PR TITLE
Fixed cursor behavior in editor

### DIFF
--- a/src/main/frontend/handler/editor.cljs
+++ b/src/main/frontend/handler/editor.cljs
@@ -2556,7 +2556,8 @@
             :down util/get-next-block-non-collapsed)
         sibling-block (f (gdom/getElement (state/get-editing-block-dom-id)))
         {:block/keys [uuid content format]} (state/get-edit-block)]
-    (when sibling-block
+    (cond
+      sibling-block
       (when-let [sibling-block-id (dom/attr sibling-block "blockid")]
         (let [value (state/get-edit-content)]
           (when (not= (clean-content! format content)
@@ -2568,7 +2569,10 @@
               block (db/pull repo '[*] [:block/uuid new-uuid])]
           (edit-block! block
                        [direction line-pos]
-                       new-id))))))
+                       new-id))
+
+      :up (cursor/move-cursor-to input 0)
+      :down (cursor/move-cursor-to-end input)))))
 
 (defn keydown-up-down-handler
   [direction]


### PR DESCRIPTION
I fixed an issue where the cursor would not snap to the end of the line in the editor
